### PR TITLE
murray: Include vendor_boot.img in installation zip

### DIFF
--- a/kickstart/attachment/xqcc54
+++ b/kickstart/attachment/xqcc54
@@ -1,6 +1,7 @@
 /boot/hybris-boot.img
 /boot/hybris-recovery.img
 /boot/dtbo.img
+/boot/vendor_boot.img
 droid-config-xqcc54-out-of-image-files
 droid-flashing-tools
 /etc/hw-release


### PR DESCRIPTION
Needed by flash script.

[murray] Include vendor_boot.img in installation zip. JB#61985