### PR TITLE
configs: Disable second SIM slot in AppSupport

### DIFF
--- a/sparse/etc/appsupport.conf.d/30-hybris.conf
+++ b/sparse/etc/appsupport.conf.d/30-hybris.conf
@@ -1,0 +1,2 @@
+[Config]
+Multisim=false


### PR DESCRIPTION
Number of SIM slots needs to be in sync with host. Should be re-enabled once eSIM support is added.

[configs] Disable second SIM slot in AppSupport. JB#62111