### PR TITLE
patterns: Require sailfish-fpd

### DIFF
--- a/patterns/patterns-sailfish-device-adaptation-pdx225.inc
+++ b/patterns/patterns-sailfish-device-adaptation-pdx225.inc
@@ -61,6 +61,7 @@ Requires: rfkill
 
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption


### PR DESCRIPTION
As sailfish-devicelock-fpd no longer explicitly requires sailfish-fpd, it needs to be pulled in via patterns.

[patterns] Require sailfish-fpd. JB#62474